### PR TITLE
Channel Error Callback functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,4 +343,12 @@ export class AmqpAdapter extends Adapter {
     serverSideEmit(packet: any[]): void {
         throw new Error('this adapter does not support the serverSideEmit() functionality');
     }
+
+    onPublishChannelErrorCallback = (callback: (err: Error) => void) => {
+        this.publishChannel.on('error', callback);
+    }
+
+    onConsumeChannelErrorCallback = (callback: (err: Error) => void) => {
+        this.consumeChannel.on('error', callback);
+    }
 }


### PR DESCRIPTION
Added onPublishChannelErrorCallback and onConsumeChannelErrorCallback functions allow users to add on error callbacks for the publish and consume channels. The should allow developers to have a better understand if there is error thrown from the channels.